### PR TITLE
Fix YAML syntax in services.yml file

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,9 +9,9 @@ services:
     captcha.type:
         class: %gregwar_captcha.captcha_type.class%
         arguments:
-            - @session
-            - @gregwar_captcha.generator
-            - @translator
+            - '@session'
+            - '@gregwar_captcha.generator'
+            - '@translator'
             - %gregwar_captcha.config%
         tags:
             - { name: form.type, alias: captcha }
@@ -19,10 +19,10 @@ services:
     gregwar_captcha.generator:
         class: %gregwar_captcha.captcha_generator.class%
         arguments:
-            - @router
-            - @gregwar_captcha.captcha_builder
-            - @gregwar_captcha.phrase_builder
-            - @gregwar_captcha.image_file_handler
+            - '@router'
+            - '@gregwar_captcha.captcha_builder'
+            - '@gregwar_captcha.phrase_builder'
+            - '@gregwar_captcha.image_file_handler'
 
     gregwar_captcha.image_file_handler:
         class: %gregwar_captcha.image_file_handler.class%


### PR DESCRIPTION
The '@' character is supposed to be a reserved indicator for YAML. Therefore when using it at the beginning of a string (as in this case) we should enclose it in quotes.
http://yaml.org/spec/1.2/spec.html#id2774228

Also, since Symfony 2.8 this kind of usage is already marked as deprecated: https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#yaml
